### PR TITLE
Allowing update of annotation

### DIFF
--- a/src/components/EditableAnnotation.js
+++ b/src/components/EditableAnnotation.js
@@ -19,6 +19,15 @@ export default class EditableAnnotation extends React.Component {
     })
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      x: nextProps.x,
+      y: nextProps.y,
+      dx: nextProps.dx,
+      dy: nextProps.dy
+    })
+  }
+
   getData() {
     return Object.assign({}, this.props, this.state)
   }


### PR DESCRIPTION
We had a scenario where we needed to update the x and y of the annotation based of the image resizing. This could also be useful for scenarios such as one person viewing an annotation whilst another person is updating the annotation. Currently you can't manually update the x and y.

We are also looking at using SVG scaling to solve the resizing issue but this still might be relevant for other situations.