### PR TITLE
Update prop-types and viz-annotiation

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "prop-types": "^15.6.2",
-    "viz-annotation": "^0.0.1-4"
+    "prop-types": "15.6.2",
+    "viz-annotation": "0.0.1-3"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "prop-types": "15.6.0",
-    "viz-annotation": "0.0.1-3"
+    "prop-types": "^15.6.2",
+    "viz-annotation": "^0.0.1-4"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
This PR updates `prop-types` and `viz-annotiation` to include the latest patch releases and uses semantic versioning in order to include future patches when using it as a library.

This change is handy since `prop-types@15.6.2` removed some old internal dependencies which can cause problems during module resolution when using it in larger projects.